### PR TITLE
feat: make cstree integration optional

### DIFF
--- a/cab/cab-why/Cargo.toml
+++ b/cab/cab-why/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 version.workspace    = true
 
 [features]
-default              = ["cstree"]
-cstree               = ["dep:cstree"]
+default = [ "cstree" ]
+cstree  = [ "dep:cstree" ]
 
 [dependencies]
 anyhow.workspace               = true

--- a/cab/cab-why/Cargo.toml
+++ b/cab/cab-why/Cargo.toml
@@ -6,10 +6,15 @@ publish.workspace    = true
 repository.workspace = true
 version.workspace    = true
 
+[features]
+default              = ["cstree"]
+cstree               = ["dep:cstree"]
+
 [dependencies]
 anyhow.workspace               = true
 const-str.workspace            = true
 cstree.workspace               = true
+cstree.optional                = true
 scopeguard.workspace           = true
 smallvec.workspace             = true
 terminal_size.workspace        = true

--- a/cab/cab-why/src/text/size.rs
+++ b/cab/cab-why/src/text/size.rs
@@ -83,12 +83,14 @@ impl From<usize> for Size {
     }
 }
 
+#[cfg(feature = "cstree")]
 impl From<Size> for cstree::text::TextSize {
     fn from(this: Size) -> Self {
         cstree::text::TextSize::new(*this)
     }
 }
 
+#[cfg(feature = "cstree")]
 impl From<cstree::text::TextSize> for Size {
     fn from(that: cstree::text::TextSize) -> Self {
         Self(that.into())

--- a/cab/cab-why/src/text/span.rs
+++ b/cab/cab-why/src/text/span.rs
@@ -170,12 +170,14 @@ impl From<ops::Range<usize>> for Span {
     }
 }
 
+#[cfg(feature = "cstree")]
 impl From<Span> for cstree::text::TextRange {
     fn from(this: Span) -> Self {
         cstree::text::TextRange::new(this.start.into(), this.end.into())
     }
 }
 
+#[cfg(feature = "cstree")]
 impl From<cstree::text::TextRange> for Span {
     fn from(that: cstree::text::TextRange) -> Self {
         Self {
@@ -191,12 +193,14 @@ pub trait IntoSpan {
     fn span(&self) -> Span;
 }
 
+#[cfg(feature = "cstree")]
 impl<S: cstree::Syntax> IntoSpan for cstree::syntax::SyntaxToken<S> {
     fn span(&self) -> Span {
         self.text_range().into()
     }
 }
 
+#[cfg(feature = "cstree")]
 impl<S: cstree::Syntax> IntoSpan for cstree::syntax::SyntaxNode<S> {
     fn span(&self) -> Span {
         self.text_range().into()


### PR DESCRIPTION
Not sure if this is within scope, but its a dependency that isnt necessarily wanted by other non-cab consumers of cab-why 